### PR TITLE
still broken but at least URL endpoint is right

### DIFF
--- a/groovebox/api/vendors.py
+++ b/groovebox/api/vendors.py
@@ -239,7 +239,7 @@ class Crawler(object):
             "rows": limit,
             "output": "json"
             }
-        r = requests.get(Archive.METADATA_URL, params=params).json()
+        r = requests.get(Archive.API_URL, params=params).json()
         rs = r['response']['docs']
         return list(filter(lambda r: r['identifier'] != 'etree', rs))
 


### PR DESCRIPTION
r['response']['docs'] appears to return empty array every time still, but prior to this fix the response was 404
